### PR TITLE
Fix bug showing 10hs 60min left

### DIFF
--- a/dateHelperFunctions.js
+++ b/dateHelperFunctions.js
@@ -151,13 +151,12 @@ function getTimeOfEventAsText(eventDate) {
 
 
 function getTimeToEventAsText(eventDate) {
-
     const now = new Date();
     const diff = Math.abs(eventDate - now);
-    const diffInMins = diff / (1000 * 60);
+    const diffInMins = Math.ceil(diff / (1000 * 60));
 
     const hrDiff = Math.floor(diffInMins / 60);
-    const minDiff = Math.ceil(diffInMins % 60);
+    const minDiff = diffInMins % 60;
 
     return hrDiff > 0 ? `${hrDiff} hr ${minDiff} min` : `${minDiff} min`;
 }

--- a/dateHelperFunctions.js
+++ b/dateHelperFunctions.js
@@ -159,13 +159,5 @@ function getTimeToEventAsText(eventDate) {
     const hrDiff = Math.floor(diffInMins / 60);
     const minDiff = Math.ceil(diffInMins % 60);
 
-    let diffText;
-    if (hrDiff === 0) {
-        diffText = minDiff + " min";
-    }
-    else {
-        diffText = hrDiff + " hr " + minDiff + " min";
-    }
-
-    return diffText;
+    return hrDiff > 0 ? `${hrDiff} hr ${minDiff} min` : `${minDiff} min`;
 }


### PR DESCRIPTION
I found instances in which the time will show X hours and 60 minutes

![image](https://user-images.githubusercontent.com/58179604/220389813-472deaae-70c9-4f8e-b8dd-9be53d9d7b1f.png)

Assuming 119.5 minutes left, it would do:
```js
const diffInMin = 119.5;
const diffHr = Math.floor(119.5 / 60); // Floor of 1.99 is 1 hour
const diffMin = Math.ceil(119.5 % 60); // Ceiling of 59.5 is 60 min
```

But now;

```js
const diffInMin = Math.ceil(119.5); // 120 mins
const diffHr = Math.floor(120 / 60); // 2 hours
const diffMin = 120 % 60; // 0 min
```