### PR TITLE
14: filter out full day events

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -8,6 +8,15 @@ function trimLongEventName(summary) {
   }
 }
 
+function notFullDayEvent(event) {
+  return !(
+    event.date.getHours() === 0 &&
+    event.date.getMinutes() === 0 &&
+    event.end.getHours() === 0 &&
+    event.end.getMinutes() === 0
+  );
+}
+
 export function getTodaysEvents(calendarSource) {
   const src = calendarSource;
   src._loadEvents(true);
@@ -18,7 +27,7 @@ export function getTodaysEvents(calendarSource) {
   const tomorrow = new Date(today);
   tomorrow.setDate(today.getDate() + 1);
 
-  const todaysEvents = src.getEvents(today, tomorrow);
+  const todaysEvents = src.getEvents(today, tomorrow).filter(notFullDayEvent);
 
   return todaysEvents;
 }


### PR DESCRIPTION
resolves #14 

As proposed in #14, added filtering out full day events (like holidays and birthdays) by checking if their start and end times are equal to midnight. 

Didn't made that as an option, because showing all day events is pointless: they cover all other, useful events.

Sample printout of calendar used for debugging, my offset is UTC+7, so `Full day event` is shifted a little bit:

```json
[
  {
    "id": "c8ecc9fea7f0406988b8c605b04fefb613ab346c\n5j6pl9qso5mvlkalg1dtfdne9o@google.com\n",
    "date": "2024-05-22T17:00:00.000Z",
    "end": "2024-05-23T17:00:00.000Z",
    "summary": "Full day event"
  },
  {
    "id": "931484d66ce626720fba87683bdfbd64bfec474f\n69daqsc22eo2ai78s776otqk3q@google.com\n",
    "date": "2024-05-23T10:00:00.000Z",
    "end": "2024-05-23T12:00:00.000Z",
    "summary": "Ordinary one"
  },
]
```

Thanks for your work!