### PR TITLE
24: bump to gnome-shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,9 @@
   "name": "Next Up",
   "description": "Show your next calendar event in the status bar",
   "uuid": "next-up@artisticat1.github.com",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/artisticat1/gnome-next-up",
   "settings-schema": "org.gnome.shell.extensions.next-up",
   "gettext-domain": "next-up-indicator-extension",
-  "version": 6
+  "version": 7
 }

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -30,7 +30,6 @@ export default class Indicator extends PanelMenu.Button {
       y_align: Clutter.ActorAlign.CENTER,
       reactive: true,
       x_expand: true,
-      pack_start: false,
     });
 
     this._alarmIcon = new St.Icon({


### PR DESCRIPTION
Migrates to Gnome-Shell v.48, as described in #24 